### PR TITLE
feat: autoload + usage instructions instead of automatically adding

### DIFF
--- a/README.org
+++ b/README.org
@@ -31,11 +31,19 @@ and add this to your init.el file:
   (load-file "/path/to/odin-ts-mode.el")
 #+end_src
 *** use-package
-You can also use use-package to install this package, simply add this to your init.el file:
+You can also use use-package to install this package, simply add this to your init.el file (you can skip the usage step below with this):
 #+begin_src elisp
   (use-package odin-ts-mode
-    :ensure (:host github :repo "Sampie159/odin-ts-mode"))
+    :ensure (:host github :repo "Sampie159/odin-ts-mode")
+    :mode "\\.odin\\'")
 #+end_src
+
+** Usage
+Add this to your configuration:
+#+begin_src elisp
+  (add-to-list 'auto-mode-alist '("\\.odin\\'" . odin-ts-mode))
+#+end_src
+
 ** TODO Roadmap? [2/3]
 - [-] Syntax Highlighting [1/2]
   - [X] Get something working

--- a/odin-ts-mode.el
+++ b/odin-ts-mode.el
@@ -259,6 +259,7 @@
 
   (treesit-major-mode-setup))
 
+;;;###autoload
 (define-derived-mode odin-ts-mode prog-mode "odin"
   "Major mode for editing odin files, powered by tree-sitter."
   :group 'odin-ts
@@ -267,9 +268,6 @@
   (when (treesit-ready-p 'odin)
     (treesit-parser-create 'odin)
     (odin-ts-mode-setup)))
-
-(when (treesit-ready-p 'odin)
-  (add-to-list 'auto-mode-alist '("\\.odin\\'" . odin-ts-mode)))
 
 (provide 'odin-ts-mode)
 


### PR DESCRIPTION
This is a breaking change, but has the advantage of allowing easy lazy loading. This is also what every other ts-mode package does, so it would be a good idea to follow the pattern.