### PR TITLE
Fix paragraph fill for multline comments

### DIFF
--- a/odin-ts-mode.el
+++ b/odin-ts-mode.el
@@ -50,6 +50,7 @@
 
 (require 'treesit)
 (require 'js)
+(require 'c-ts-common)
 
 (defgroup odin-ts nil
   "Major mode for editing odin files."
@@ -254,8 +255,8 @@
   ;; Imenu
   (setq-local treesit-simple-imenu-settings odin-ts-mode--imenu-settings)
 
-  (setq-local comment-start "//")
-  (setq-local comment-end "")
+  ;; Comment
+  (c-ts-common-comment-setup)
 
   (treesit-major-mode-setup))
 


### PR DESCRIPTION
M-q (filling paragraph) was messing up /* comments */ together with the code if there were not separated by a blank line.

Since odin and C more or less share the way they do comments, using c-ts-common functionality seems to do the trick.