### PR TITLE
Fix highlighting of constant as a type

### DIFF
--- a/odin-ts-mode.el
+++ b/odin-ts-mode.el
@@ -195,7 +195,6 @@
    :override t
    :feature 'type
    `((struct_declaration (identifier) @font-lock-type-face)
-     (const_declaration (identifier) @font-lock-type-face)
      (type (identifier) @font-lock-type-face)
      (enum_declaration (identifier) @font-lock-type-face)
      (union_declaration (identifier) @font-lock-type-face)


### PR DESCRIPTION
The captured part in the const_declaration is a name of a constant, not the type (it's implicit here), so don't apply the type font-lock to it.