### PR TITLE
Change indentation to tree-sitter-based indenting

### DIFF
--- a/odin-ts-mode.el
+++ b/odin-ts-mode.el
@@ -266,7 +266,7 @@ PARENT should be a block_comment node."
      ((node-is "}") (and parent parent-bol) 0) ; We don't need to do all braces separately because we define indent relative to parent and not in blocks.
                                                ; I don't know why but some of the other -ts-modes dedent to (and parent parent-bol) and i'll do the same just in case
 
-     ((parent-is "$block^")              parent-bol odin-ts-mode-indent-offset)
+     ((parent-is "^block$")            parent-bol odin-ts-mode-indent-offset)
      ((parent-is "enum_declaration")   parent-bol odin-ts-mode-indent-offset)
      ((parent-is "union_declaration")  parent-bol odin-ts-mode-indent-offset)
      ((parent-is "struct_declaration") parent-bol odin-ts-mode-indent-offset)

--- a/odin-ts-mode.el
+++ b/odin-ts-mode.el
@@ -267,10 +267,17 @@ PARENT should be a block_comment node."
                                                ; I don't know why but some of the other -ts-modes dedent to (and parent parent-bol) and i'll do the same just in case
 
      ((parent-is "^block$")            parent-bol odin-ts-mode-indent-offset)
+
+     ;; Declarations
      ((parent-is "enum_declaration")   parent-bol odin-ts-mode-indent-offset)
      ((parent-is "union_declaration")  parent-bol odin-ts-mode-indent-offset)
      ((parent-is "struct_declaration") parent-bol odin-ts-mode-indent-offset)
-     ((parent-is "struct")             parent-bol odin-ts-mode-indent-offset)
+
+     ;; Anonymous struct and union types
+     ((parent-is "union_type")         parent-bol odin-ts-mode-indent-offset)
+     ((parent-is "struct_type")        parent-bol odin-ts-mode-indent-offset)
+
+     ((parent-is "^struct$")           parent-bol odin-ts-mode-indent-offset)
      ((parent-is "parameters")         parent-bol odin-ts-mode-indent-offset)
      ((parent-is "tuple_type")         parent-bol odin-ts-mode-indent-offset)
      ((parent-is "call_expression")    parent-bol odin-ts-mode-indent-offset)

--- a/odin-ts-mode.el
+++ b/odin-ts-mode.el
@@ -247,6 +247,17 @@
     ("Function" "\\`overloaded_procedure_declaration\\'" nil nil))
   "Imenu settings used by `odin-ts-mode`.")
 
+;; Once again shamelessely stolen from c-ts-mode and slightly changed because the c parser
+;; has no distinciton between comment and block_comment nodes while the odin parser does
+(defun odin-ts-comment-2nd-line-matcher (_n parent &rest _)
+  "Matches if point is at the second line of a block comment.
+PARENT should be a block_comment node."
+  (and (equal (treesit-node-type parent) "block_comment")
+       (save-excursion
+         (forward-line -1)
+         (back-to-indentation)
+         (eq (point) (treesit-node-start parent)))))
+
 ;; Shamelessely ported from https://github.com/tree-sitter-grammars/tree-sitter-odin/blob/master/queries/indents.scm
 (defvar odin-ts-mode-indent-rules
   '((odin
@@ -255,7 +266,7 @@
      ((node-is "}") (and parent parent-bol) 0) ; We don't need to do all braces separately because we define indent relative to parent and not in blocks.
                                                ; I don't know why but some of the other -ts-modes dedent to (and parent parent-bol) and i'll do the same just in case
 
-     ((parent-is "block")              parent-bol odin-ts-mode-indent-offset)
+     ((parent-is "$block^")              parent-bol odin-ts-mode-indent-offset)
      ((parent-is "enum_declaration")   parent-bol odin-ts-mode-indent-offset)
      ((parent-is "union_declaration")  parent-bol odin-ts-mode-indent-offset)
      ((parent-is "struct_declaration") parent-bol odin-ts-mode-indent-offset)
@@ -268,9 +279,10 @@
      ;; Shamelessely stolen from c-ts-mode
      ((and (parent-is "block_comment") c-ts-common-looking-at-star)
       c-ts-common-comment-start-after-first-star -1)
-     (c-ts-common-comment-2nd-line-matcher
+     (odin-ts-comment-2nd-line-matcher
       c-ts-common-comment-2nd-line-anchor
       1)
+
      ((parent-is "block_comment") prev-adaptive-prefix 0)
 
      (catch-all parent-bol 0)))

--- a/odin-ts-mode.el
+++ b/odin-ts-mode.el
@@ -264,6 +264,7 @@
      ((parent-is "tuple_type")         parent-bol odin-ts-mode-indent-offset)
      ((parent-is "call_expression")    parent-bol odin-ts-mode-indent-offset)
      ((parent-is "switch_case")        parent-bol odin-ts-mode-indent-offset)
+     ((parent-is "switch_statement")   parent-bol 0)
 
      ;; Shamelessely stolen from c-ts-mode
      ((and (parent-is "block_comment") c-ts-common-looking-at-star)

--- a/odin-ts-mode.el
+++ b/odin-ts-mode.el
@@ -273,7 +273,7 @@
       1)
      ((parent-is "block_comment") prev-adaptive-prefix 0)
 
-     (catch-all parent 0)))
+     (catch-all parent-bol 0)))
   "Tree-sitter indent rules for `odin-ts-mode`.")
 
 (defun odin-ts-mode-setup ()

--- a/odin-ts-mode.el
+++ b/odin-ts-mode.el
@@ -63,6 +63,12 @@
   :type 'symbol
   :group 'odin-ts)
 
+(defcustom odin-ts-mode-indent-offset 4
+  "Number of spaces for each indentation step in `odin-ts-mode`."
+  :type 'integer
+  :safe 'integerp
+  :group 'odin-ts)
+
 (defconst odin-ts-mode--syntax-table ;; shamelessly stolen directly from odin-mode
   (let ((table (make-syntax-table)))
     (modify-syntax-entry ?\" "\"" table)
@@ -241,6 +247,33 @@
     ("Function" "\\`overloaded_procedure_declaration\\'" nil nil))
   "Imenu settings used by `odin-ts-mode`.")
 
+;; Shamelessely ported from https://github.com/tree-sitter-grammars/tree-sitter-odin/blob/master/queries/indents.scm
+(defvar odin-ts-mode-indent-rules
+  '((odin
+     ((node-is "]") parent-bol 0)
+     ((node-is ")") parent-bol 0)
+     ((node-is "}") (and parent parent-bol) 0) ; We don't need to do all braces separately because we define indent relative to parent and not in blocks.
+                                               ; I don't know why but some of the other -ts-modes dedent to (and parent parent-bol) and i'll do the same just in case
+
+     ((parent-is "block")              parent-bol odin-ts-mode-indent-offset)
+     ((parent-is "enum_declaration")   parent-bol odin-ts-mode-indent-offset)
+     ((parent-is "union_declaration")  parent-bol odin-ts-mode-indent-offset)
+     ((parent-is "struct_declaration") parent-bol odin-ts-mode-indent-offset)
+     ((parent-is "struct")             parent-bol odin-ts-mode-indent-offset)
+     ((parent-is "parameters")         parent-bol odin-ts-mode-indent-offset)
+     ((parent-is "tuple_type")         parent-bol odin-ts-mode-indent-offset)
+     ((parent-is "call_expression")    parent-bol odin-ts-mode-indent-offset)
+     ((parent-is "switch_case")        parent-bol odin-ts-mode-indent-offset)
+
+     ;; Shamelessely stolen from c-ts-mode
+     ((and (parent-is "block_comment") c-ts-common-looking-at-star)
+      c-ts-common-comment-start-after-first-star -1)
+     (c-ts-common-comment-2nd-line-matcher
+      c-ts-common-comment-2nd-line-anchor
+      1)
+     ((parent-is "block_comment") prev-adaptive-prefix 0)))
+  "Tree-sitter indent rules for `odin-ts-mode`.")
+
 (defun odin-ts-mode-setup ()
   "Setup treesit for `odin-ts-mode`."
 
@@ -249,8 +282,7 @@
               treesit-font-lock-feature-list odin-ts-mode--font-lock-feature-list)
 
   ;; Indentation
-  (setq-local indent-line-function 'js-indent-line
-              electric-indent-chars (append "{}():;," electric-indent-chars))
+  (setq-local treesit-simple-indent-rules odin-ts-mode-indent-rules)
 
   ;; Imenu
   (setq-local treesit-simple-imenu-settings odin-ts-mode--imenu-settings)

--- a/odin-ts-mode.el
+++ b/odin-ts-mode.el
@@ -264,7 +264,6 @@
      ((parent-is "tuple_type")         parent-bol odin-ts-mode-indent-offset)
      ((parent-is "call_expression")    parent-bol odin-ts-mode-indent-offset)
      ((parent-is "switch_case")        parent-bol odin-ts-mode-indent-offset)
-     ((parent-is "switch_statement")   parent-bol 0)
 
      ;; Shamelessely stolen from c-ts-mode
      ((and (parent-is "block_comment") c-ts-common-looking-at-star)
@@ -272,7 +271,9 @@
      (c-ts-common-comment-2nd-line-matcher
       c-ts-common-comment-2nd-line-anchor
       1)
-     ((parent-is "block_comment") prev-adaptive-prefix 0)))
+     ((parent-is "block_comment") prev-adaptive-prefix 0)
+
+     (catch-all parent 0)))
   "Tree-sitter indent rules for `odin-ts-mode`.")
 
 (defun odin-ts-mode-setup ()


### PR DESCRIPTION
Changes indentation rules to tree-sitter-based one

I based them on the indents.scm found at https://github.com/tree-sitter-grammars/tree-sitter-odin/blob/master/queries/indents.scm

This fixes situations like

```odin
switch foo {
case 1:
    some_function()
    case: // <-- this should not be indented
    some_other_function()
}
```

I'm by no means an experienced odin programmer or emacs plugin developer, so please test this well :P