### PR TITLE
fix highlighting for nested member access and for identifiers in struct literal fields

### DIFF
--- a/odin-ts-mode.el
+++ b/odin-ts-mode.el
@@ -226,7 +226,7 @@
    :override t
    :feature 'property
    `((field (identifier) @font-lock-property-name-face)
-     (struct_field (identifier) @font-lock-property-name-face)
+     (struct_field (identifier) @font-lock-property-name-face "=")
      (member_expression "." (identifier) @font-lock-property-use-face)))
   "Font lock rules used by `odin-ts-mode`.")
 

--- a/odin-ts-mode.el
+++ b/odin-ts-mode.el
@@ -227,8 +227,7 @@
    :feature 'property
    `((field (identifier) @font-lock-property-name-face)
      (struct_field (identifier) @font-lock-property-name-face)
-     (member_expression (identifier) (identifier) @font-lock-property-use-face))
-   )
+     (member_expression "." (identifier) @font-lock-property-use-face)))
   "Font lock rules used by `odin-ts-mode`.")
 
 (defvar odin-ts-mode--font-lock-feature-list


### PR DESCRIPTION
I noticed another issue where nested member access would be highlighted using the wrong font lock.
The original capture only captured expressions of the form `(member_expression (identifier) (identifier) @font-lock-property-use-face)`.

The two examples below would have `c` highlighted incorrectly (specifically, using `font-lock-variable-use-face`)

```c
// (member_expression (index_expression (identifier) [ (identifier) ]) . (identifier))
a[b].c
// (member_expression (member_expression (identifier) . (identifier)) . (identifier))
a.b.c
```

This is fixed by matching expressions of the form `(member_expression "." (identifier) @font-lock-property-use-face)` instead