### PR TITLE
feat: added navigation capabilities

### DIFF
--- a/odin-ts-mode.el
+++ b/odin-ts-mode.el
@@ -295,6 +295,27 @@ PARENT should be a block_comment node."
      (catch-all parent-bol 0)))
   "Tree-sitter indent rules for `odin-ts-mode`.")
 
+(defvar odin-ts-mode--thing-settings
+  `((odin
+     (defun ,(rx "declaration"))
+
+     (sexp (not (or (and named
+                         ,(rx bos (or "comment"
+                                      "block_comment"
+                                      "block"
+                                      "tagged_block"
+                                      "foreign_block")))
+                    (and anonymous
+                         ,(rx (or "{" "}" "[" "]"
+                                  "(" ")" ",")))))))
+    (list ,(rx bos (or "parameters"
+                       "default_parameter"
+                       "polymorphic_parameters")
+               eos))
+    (sentence ,(rx (or "statement"
+                       "clause"))))
+  "`treesit-thing-settings' for Odin.")
+
 (defun odin-ts-mode-setup ()
   "Setup treesit for `odin-ts-mode`."
 
@@ -310,6 +331,9 @@ PARENT should be a block_comment node."
 
   ;; Comment
   (c-ts-common-comment-setup)
+
+  ;; Navigation
+  (setq-local treesit-thing-settings odin-ts-mode--thing-settings)
 
   (treesit-major-mode-setup))
 


### PR DESCRIPTION
Following `python.el`, `c-ts-mode.el` and node types from  [tree-sitter-odin/src/node-types.json](https://github.com/tree-sitter-grammars/tree-sitter-odin/blob/master/src/node-types.json).

The following functions now appear to work as intended:
- `treesit-forward-sexp`
- `treesit-beginning-of-defun`
- `treesit-end-of-defun`
- `narrow-to-defun`